### PR TITLE
Force RNN layer to be dynamic

### DIFF
--- a/tensorlayer/layers/recurrent.py
+++ b/tensorlayer/layers/recurrent.py
@@ -215,6 +215,24 @@ class RNN(Layer):
         batch_size = inputs.get_shape().as_list()[0]
         total_steps = inputs.get_shape().as_list()[1]
 
+        '''
+        Since sequence_length is not passed into computational graph when build a static model, we force sequence_length to be not None to get dynamic RNN. 
+        Here is an example:
+        
+          ni = tl.layers.Input(inputs_shape, name='input_layer')
+          seq = tl.layers.retrieve_seq_length_op3(ni)
+          cell = tf.keras.layers.LSTMCell(units=n_hidden, recurrent_dropout=0)
+          out = RNN(cell=cell, 
+                      return_last_output=True, 
+                      return_last_state=False,
+                      return_seq_2d=True)(ni,sequence_length=seq)
+          nn = tl.layers.Dense(n_units=2, act=tf.nn.softmax, name="dense")(out)
+          model = tl.models.Model(inputs=ni, outputs=nn, name='rnn')
+          
+        We test this code that sequence_length is not passed to the model whatever it is, which induce a lower accuracy for training and validation
+        '''        
+        sequence_length = tl.layers.retrieve_seq_length_op3(inputs)
+        
         # checking the type and values of sequence_length
         if sequence_length is not None:
             if isinstance(sequence_length, list):


### PR DESCRIPTION


<!-- ============================================================================================================
Thanks for contributing to _TensorLayer_! We really appreciate your help !
Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] 
============================================================================================================= -->

### Checklist
- [ ] I've tested that my changes are compatible with the latest version of Tensorflow.
- [ ] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Build a dynamic RNN model in static mode for deploying. The dynamic RNN means outputs the last without-padding output.

### Description
<!--- Describe your changes in detail -->
Although, the official document gives an example of building dynamic RNN model in eager mode, we want the model to be static for serving. 

'''
>>> data = tf.convert_to_tensor(data, dtype=tf.float32)
>>> class DynamicRNNExample(tl.models.Model):
>>>     def __init__(self):
>>>         super(DynamicRNNExample, self).__init__()
>>>         self.rnnlayer = tl.layers.RNN(
>>>             cell=tf.keras.layers.SimpleRNNCell(units=6, dropout=0.1), in_channels=1, return_last_output=True,
>>>             return_last_state=True
>>>         )
>>>     def forward(self, x):
>>>         z, s = self.rnnlayer(x, sequence_length=tl.layers.retrieve_seq_length_op3(x))
>>>         return z, s
>>> model = DynamicRNNExample()
>>> model.eval()
>>> output, state = model(data)
'''

The current RNN layer cannot be built as a dynamic RNN layer for a static model, which is hard to save as trackable model for serving. I test the following code

'''
  ni = tl.layers.Input(inputs_shape, name='input_layer')
  seq = tl.layers.retrieve_seq_length_op3(ni)
  cell = tf.keras.layers.LSTMCell(units=n_hidden, recurrent_dropout=0)
  out = RNN(cell=cell, 
                      return_last_output=True, 
                      return_last_state=False,
                      return_seq_2d=True)(ni,sequence_length=seq)
  nn = tl.layers.Dense(n_units=2, act=tf.nn.softmax, name="dense")(out)
  model = tl.models.Model(inputs=ni, outputs=nn, name='rnn')
'''

which actually is built as a static RNN. 

we force the RNN always to be dynamic to promote the accuracy. 